### PR TITLE
Add support for multiple video urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM bellsoft/liberica-openjdk-alpine-musl:21.0.1-16 AS build
 WORKDIR /usr/src/app
 # cache dependencies
 COPY ./gradlew                         ./
+COPY ./gradle.properties               ./
 COPY ./settings.gradle.kts             ./
 COPY ./gradle                          ./gradle/
 COPY ./buildSrc/src                    ./buildSrc/src/

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/event/integration/CreateEventIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/event/integration/CreateEventIntegrationTest.kt
@@ -49,7 +49,7 @@ class CreateEventIntegrationTest : IntegrationTest() {
 
         shouldThrow<FeignException.InternalServerError> {
             client.createEvent(CREATE_EVENT)
-        } should { it.contentUTF8() shouldContain ""","status":500,"error":"Internal Server Error","path":"/api/v1/event"}""" }
+        } should { it.contentUTF8() shouldContain ""","status":500,"error":"Internal Server Error"""" }
     }
 
     private companion object {

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/AddVideoToEventIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/AddVideoToEventIntegrationTest.kt
@@ -38,7 +38,7 @@ class AddVideoToEventIntegrationTest(
                 videos = listOf(
                     Video(
                         id = videoEntity.id,
-                        urls = emptyList(),
+                        urls = videoEntity.urls,
                         title = videoEntity.title,
                         uploadedAt = videoEntity.uploadedAt,
                         visible = videoEntity.visible

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/AddVideoToEventIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/AddVideoToEventIntegrationTest.kt
@@ -22,7 +22,7 @@ class AddVideoToEventIntegrationTest(
     @Test
     fun `it should return 200 and add video to event`() {
         val eventEntity = eventRepository.save(DetailedEventEntity(url = "url", title = "title"))
-        val videoEntity = videoRepository.save(DetailedVideoEntity(urls = "url", title = "title"))
+        val videoEntity = videoRepository.save(DetailedVideoEntity(title = "title"))
 
         val actual = client.addVideoToEvent(eventEntity.id, videoEntity.id)
 
@@ -38,7 +38,7 @@ class AddVideoToEventIntegrationTest(
                 videos = listOf(
                     Video(
                         id = videoEntity.id,
-                        url = videoEntity.urls,
+                        urls = emptyList(),
                         title = videoEntity.title,
                         uploadedAt = videoEntity.uploadedAt,
                         visible = videoEntity.visible
@@ -50,7 +50,7 @@ class AddVideoToEventIntegrationTest(
 
     @Test
     fun `it should return 500 when event does not exist`() {
-        val videoEntity = videoRepository.save(DetailedVideoEntity(urls = "url", title = "title"))
+        val videoEntity = videoRepository.save(DetailedVideoEntity(title = "title"))
 
         shouldThrow<FeignException.InternalServerError> {
             client.addVideoToEvent(

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/AddVideoToEventIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/AddVideoToEventIntegrationTest.kt
@@ -22,7 +22,7 @@ class AddVideoToEventIntegrationTest(
     @Test
     fun `it should return 200 and add video to event`() {
         val eventEntity = eventRepository.save(DetailedEventEntity(url = "url", title = "title"))
-        val videoEntity = videoRepository.save(DetailedVideoEntity(url = "url", title = "title"))
+        val videoEntity = videoRepository.save(DetailedVideoEntity(urls = "url", title = "title"))
 
         val actual = client.addVideoToEvent(eventEntity.id, videoEntity.id)
 
@@ -38,7 +38,7 @@ class AddVideoToEventIntegrationTest(
                 videos = listOf(
                     Video(
                         id = videoEntity.id,
-                        url = videoEntity.url,
+                        url = videoEntity.urls,
                         title = videoEntity.title,
                         uploadedAt = videoEntity.uploadedAt,
                         visible = videoEntity.visible
@@ -50,7 +50,7 @@ class AddVideoToEventIntegrationTest(
 
     @Test
     fun `it should return 500 when event does not exist`() {
-        val videoEntity = videoRepository.save(DetailedVideoEntity(url = "url", title = "title"))
+        val videoEntity = videoRepository.save(DetailedVideoEntity(urls = "url", title = "title"))
 
         shouldThrow<FeignException.InternalServerError> {
             client.addVideoToEvent(

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/RemoveVideoFromEventIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/RemoveVideoFromEventIntegrationTest.kt
@@ -21,12 +21,12 @@ class RemoveVideoFromEventIntegrationTest(
 
     @Test
     fun `it should return 204 and remove video from event`() {
-        val videoEntity = videoRepository.save(DetailedVideoEntity(url = "url", title = "title"))
+        val videoEntity = videoRepository.save(DetailedVideoEntity(urls = "url", title = "title"))
         val eventEntity = eventRepository.save(DetailedEventEntity(url = "url", title = "title"))
             .apply {
                 this.videos = listOf(
                     SimpleVideoEntity(
-                        url = videoEntity.url,
+                        urls = videoEntity.urls,
                         title = videoEntity.title
                     ).apply { this.id = videoEntity.id }
                 )
@@ -50,7 +50,7 @@ class RemoveVideoFromEventIntegrationTest(
 
     @Test
     fun `it should return 404 when event does not exist`() {
-        val videoEntity = videoRepository.save(DetailedVideoEntity(url = "url", title = "title"))
+        val videoEntity = videoRepository.save(DetailedVideoEntity(urls = "url", title = "title"))
 
         shouldThrow<FeignException.NotFound> {
             client.removeVideoFromEvent(

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/RemoveVideoFromEventIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/RemoveVideoFromEventIntegrationTest.kt
@@ -21,12 +21,11 @@ class RemoveVideoFromEventIntegrationTest(
 
     @Test
     fun `it should return 204 and remove video from event`() {
-        val videoEntity = videoRepository.save(DetailedVideoEntity(urls = "url", title = "title"))
+        val videoEntity = videoRepository.save(DetailedVideoEntity(title = "title"))
         val eventEntity = eventRepository.save(DetailedEventEntity(url = "url", title = "title"))
             .apply {
                 this.videos = listOf(
                     SimpleVideoEntity(
-                        urls = videoEntity.urls,
                         title = videoEntity.title
                     ).apply { this.id = videoEntity.id }
                 )
@@ -50,7 +49,7 @@ class RemoveVideoFromEventIntegrationTest(
 
     @Test
     fun `it should return 404 when event does not exist`() {
-        val videoEntity = videoRepository.save(DetailedVideoEntity(urls = "url", title = "title"))
+        val videoEntity = videoRepository.save(DetailedVideoEntity(title = "title"))
 
         shouldThrow<FeignException.NotFound> {
             client.removeVideoFromEvent(

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/member/integration/CreateMemberIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/member/integration/CreateMemberIntegrationTest.kt
@@ -90,7 +90,7 @@ class CreateMemberIntegrationTest(
         shouldThrow<FeignException.InternalServerError> {
             client.createMember(CreateMember(url = CREATE_MEMBER.url, name = CREATE_MEMBER.name))
         } should {
-            it.contentUTF8() shouldContain ""","status":500,"error":"Internal Server Error","path":"/api/v1/member"}"""
+            it.contentUTF8() shouldContain ""","status":500,"error":"Internal Server Error""""
         }
     }
 

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/metrics/integration/ReadMetricsIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/metrics/integration/ReadMetricsIntegrationTest.kt
@@ -28,7 +28,7 @@ class ReadMetricsIntegrationTest(
 
     @Test
     fun `it should return 200 and metrics with 1 for each value`() {
-        this.videoRepository.save(DetailedVideoEntity(url = "url", title = "title"))
+        this.videoRepository.save(DetailedVideoEntity(urls = "url", title = "title"))
         this.eventRepository.save(DetailedEventEntity(url = "url", title = "title"))
         this.memberRepository.save(DetailedMemberEntity(url = "url", name = "name"))
 

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/metrics/integration/ReadMetricsIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/metrics/integration/ReadMetricsIntegrationTest.kt
@@ -28,7 +28,7 @@ class ReadMetricsIntegrationTest(
 
     @Test
     fun `it should return 200 and metrics with 1 for each value`() {
-        this.videoRepository.save(DetailedVideoEntity(urls = "url", title = "title"))
+        this.videoRepository.save(DetailedVideoEntity(title = "title"))
         this.eventRepository.save(DetailedEventEntity(url = "url", title = "title"))
         this.memberRepository.save(DetailedMemberEntity(url = "url", name = "name"))
 

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/CreateVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/CreateVideoIntegrationTest.kt
@@ -23,14 +23,14 @@ class CreateVideoIntegrationTest(
 
     @Test
     fun `it should return 201 and video`() {
-        val actual = client.createVideo(CREATE_EVENT)
+        val actual = client.createVideo(CREATE_VIDEO)
 
         assertSoftly(actual) {
             statusCode shouldBeEqual org.springframework.http.HttpStatusCode.valueOf(201)
             body!! shouldBeEqual Video(
                 id = actual.body!!.id,
                 urls = emptyList(),
-                title = CREATE_EVENT.title,
+                title = CREATE_VIDEO.title,
                 visible = false,
                 uploadedAt = LocalDate.now()
             )
@@ -40,15 +40,15 @@ class CreateVideoIntegrationTest(
 
     @Test
     fun `it should retun 500 when duplicate urls were specified`() {
-        videoRepository.save(DetailedVideoEntity(title = CREATE_EVENT.title))
+        videoRepository.save(DetailedVideoEntity(title = CREATE_VIDEO.title))
 
         shouldThrow<FeignException.InternalServerError> {
-            client.createVideo(CREATE_EVENT)
-        } should { it.contentUTF8() shouldContain ""","status":500,"error":"Internal Server Error","path":"/api/v1/video"}""" }
+            client.createVideo(CREATE_VIDEO)
+        } should { it.contentUTF8() shouldContain ""","status":500,"error":"Internal Server Error"""" }
     }
 
     private companion object {
-        private val CREATE_EVENT = CreateVideo(
+        private val CREATE_VIDEO = CreateVideo(
             title = "title"
         )
     }

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/CreateVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/CreateVideoIntegrationTest.kt
@@ -14,8 +14,6 @@ import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.http.HttpStatusCode
-import java.net.URI
 import java.time.LocalDate
 
 class CreateVideoIntegrationTest(
@@ -31,7 +29,7 @@ class CreateVideoIntegrationTest(
             statusCode shouldBeEqual org.springframework.http.HttpStatusCode.valueOf(201)
             body!! shouldBeEqual Video(
                 id = actual.body!!.id,
-                url = CREATE_EVENT.url,
+                urls = emptyList(),
                 title = CREATE_EVENT.title,
                 visible = false,
                 uploadedAt = LocalDate.now()
@@ -42,7 +40,7 @@ class CreateVideoIntegrationTest(
 
     @Test
     fun `it should retun 500 when duplicate urls were specified`() {
-        videoRepository.save(DetailedVideoEntity(url = CREATE_EVENT.url, title = CREATE_EVENT.title))
+        videoRepository.save(DetailedVideoEntity(title = CREATE_EVENT.title))
 
         shouldThrow<FeignException.InternalServerError> {
             client.createVideo(CREATE_EVENT)
@@ -51,7 +49,6 @@ class CreateVideoIntegrationTest(
 
     private companion object {
         private val CREATE_EVENT = CreateVideo(
-            url = "url",
             title = "title"
         )
     }

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/DeleteVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/DeleteVideoIntegrationTest.kt
@@ -15,7 +15,7 @@ class DeleteVideoIntegrationTest(
 
     @Test
     fun `it should return 204 and delete video`() {
-        val entity = videoRepository.save(DetailedVideoEntity(url = "url", title = "title"))
+        val entity = videoRepository.save(DetailedVideoEntity(urls = emptyList(), title = "title"))
 
         val actual = client.deleteVideo(entity.id)
 

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadAllPageableVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadAllPageableVideoIntegrationTest.kt
@@ -22,7 +22,7 @@ class ReadAllPageableVideoIntegrationTest(
     fun `it should return 200 and paged`() {
         val (entity0, entity1, entity2, entity3) = videoRepository.saveAll(
             IntRange(0, 3).map { i ->
-                DetailedVideoEntity(url = "url$i", title = "title$i").apply {
+                DetailedVideoEntity(urls = listOf("url$i"), title = "title$i").apply {
                     id = UUID.fromString("00000000-0000-0000-0000-00000000000$i")
                 }
             }
@@ -36,14 +36,14 @@ class ReadAllPageableVideoIntegrationTest(
             body!!.content.shouldContainExactly(
                 Video(
                     id = entity0.id,
-                    url = "url0",
+                    urls = listOf("url0"),
                     title = "title0",
                     uploadedAt = LocalDate.now(),
                     visible = false
                 ),
                 Video(
                     id = entity1.id,
-                    url = "url1",
+                    urls = listOf("url1"),
                     title = "title1",
                     uploadedAt = LocalDate.now(),
                     visible = false
@@ -55,14 +55,14 @@ class ReadAllPageableVideoIntegrationTest(
             body!!.content.shouldContainExactly(
                 Video(
                     id = entity2.id,
-                    url = "url2",
+                    urls = listOf("url2"),
                     title = "title2",
                     uploadedAt = LocalDate.now(),
                     visible = false
                 ),
                 Video(
                     id = entity3.id,
-                    url = "url3",
+                    urls = listOf("url3"),
                     title = "title3",
                     uploadedAt = LocalDate.now(),
                     visible = false

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadAllVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadAllVideoIntegrationTest.kt
@@ -28,7 +28,7 @@ class ReadAllVideoIntegrationTest(
 
     @Test
     fun `it should return 200 and list with 1 video`() {
-        val entity = videoRepository.save(DetailedVideoEntity(url = URL, title = TITLE))
+        val entity = videoRepository.save(DetailedVideoEntity(title = TITLE))
 
         val actual = client.getAllVideos()
 
@@ -36,7 +36,7 @@ class ReadAllVideoIntegrationTest(
             body.shouldContainExactly(
                 Video(
                     id = entity.id,
-                    url = URL,
+                    urls = emptyList(),
                     title = TITLE,
                     visible = false,
                     uploadedAt = LocalDate.now()
@@ -47,7 +47,6 @@ class ReadAllVideoIntegrationTest(
     }
 
     private companion object {
-        private const val URL = "url"
         private const val TITLE = "title"
     }
 }

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadVideoIntegrationTest.kt
@@ -27,7 +27,7 @@ class ReadVideoIntegrationTest(
 
     @Test
     fun `it should return 200 with video`() {
-        val entity = videoRepository.save(DetailedVideoEntity(url = URL, title = TITLE).apply { id = ID })
+        val entity = videoRepository.save(DetailedVideoEntity(title = TITLE).apply { id = ID })
 
         val actual = client.getVideo(entity.id)
 
@@ -35,7 +35,7 @@ class ReadVideoIntegrationTest(
             statusCode shouldBeEqual HttpStatusCode.valueOf(200)
             body!! shouldBeEqual DetailedVideo(
                 id = entity.id,
-                url = URL,
+                urls = emptyList(),
                 title = TITLE,
                 description = "",
                 visible = false,
@@ -47,7 +47,6 @@ class ReadVideoIntegrationTest(
 
     private companion object {
         private val ID = UUID.randomUUID()
-        private const val URL = "url"
         private const val TITLE = "title"
     }
 }

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/UpdateVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/UpdateVideoIntegrationTest.kt
@@ -21,7 +21,7 @@ class UpdateVideoIntegrationTest(
 
     @Test
     fun `it should return 200 and updated video`() {
-        val entity = this.videoRepository.save(DetailedVideoEntity(url = "url", title = "title"))
+        val entity = this.videoRepository.save(DetailedVideoEntity(title = "title"))
 
         val actual = client.updateVideo(entity.id, UPDATE_VIDEO)
 
@@ -29,7 +29,7 @@ class UpdateVideoIntegrationTest(
             statusCode shouldBeEqual HttpStatusCode.valueOf(200)
             body!! shouldBeEqual DetailedVideo(
                 id = entity.id,
-                url = UPDATE_VIDEO.url,
+                urls = UPDATE_VIDEO.urls,
                 title = UPDATE_VIDEO.title,
                 description = UPDATE_VIDEO.description,
                 visible = UPDATE_VIDEO.visible,
@@ -51,7 +51,7 @@ class UpdateVideoIntegrationTest(
 
     private companion object {
         private val UPDATE_VIDEO = UpdateVideo(
-            url = "updatedUrl",
+            urls = listOf("updatedUrl0", "updatedUrl1"),
             title = "updatedTitle",
             description = "updatedDescription",
             visible = true,

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/UpdateVideoVisibilityIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/UpdateVideoVisibilityIntegrationTest.kt
@@ -18,8 +18,8 @@ class UpdateVideoVisibilityIntegrationTest(
     fun `it should return 200 and updated ids`() {
         val entities = videoRepository.saveAll(
             listOf(
-                DetailedVideoEntity(url = URL_1, title = TITLE_1),
-                DetailedVideoEntity(url = URL_2, title = TITLE_2)
+                DetailedVideoEntity(title = TITLE_1),
+                DetailedVideoEntity(title = TITLE_2)
             )
         )
 
@@ -35,8 +35,8 @@ class UpdateVideoVisibilityIntegrationTest(
     fun `it should return 200 and updated ids wheen videos are being hidden`() {
         val entities = videoRepository.saveAll(
             listOf(
-                DetailedVideoEntity(url = URL_1, title = TITLE_1, visible = true),
-                DetailedVideoEntity(url = URL_2, title = TITLE_2, visible = true)
+                DetailedVideoEntity(title = TITLE_1, visible = true),
+                DetailedVideoEntity(title = TITLE_2, visible = true)
             )
         )
 
@@ -59,9 +59,7 @@ class UpdateVideoVisibilityIntegrationTest(
     }
 
     private companion object {
-        private const val URL_1 = "url1"
         private const val TITLE_1 = "title1"
-        private const val URL_2 = "url2"
         private const val TITLE_2 = "title2"
     }
 }

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/videocrew/integration/AddVideoCrewIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/videocrew/integration/AddVideoCrewIntegrationTest.kt
@@ -19,7 +19,7 @@ class AddVideoCrewIntegrationTest(
 
     @Test
     fun `it should add a member to a video`() {
-        val videoEntity = videoRepository.save(DetailedVideoEntity(url = "url", title = "title"))
+        val videoEntity = videoRepository.save(DetailedVideoEntity(title = "title"))
         val memberEntity = memberRepository.save(DetailedMemberEntity(url = "url", name = "name"))
 
         val actual = client.addPosition(videoEntity.id, "position", memberEntity.id)
@@ -28,7 +28,7 @@ class AddVideoCrewIntegrationTest(
             statusCode shouldBeEqual HttpStatusCode.valueOf(200)
             body!! shouldBeEqual DetailedVideo(
                 id = videoEntity.id,
-                url = videoEntity.url,
+                urls = videoEntity.urls,
                 title = videoEntity.title,
                 description = videoEntity.description,
                 uploadedAt = videoEntity.uploadedAt,

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/videocrew/integration/RemoveVideoCrewIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/videocrew/integration/RemoveVideoCrewIntegrationTest.kt
@@ -19,7 +19,7 @@ class RemoveVideoCrewIntegrationTest(
 
     @Test
     fun `it should return 200 and delete video crew`() {
-        val videoEntity = videoRepository.save(DetailedVideoEntity(url = "url", title = "title"))
+        val videoEntity = videoRepository.save(DetailedVideoEntity(title = "title"))
         val memberEntity = memberRepository.save(DetailedMemberEntity(url = "url", name = "name"))
         videoCrewRepository.save(VideoCrewEntity(VideoCrewEntityId(videoEntity.id, "position", memberEntity.id)))
 
@@ -29,7 +29,7 @@ class RemoveVideoCrewIntegrationTest(
             statusCode shouldBeEqual HttpStatusCode.valueOf(200)
             body!! shouldBeEqual DetailedVideo(
                 id = videoEntity.id,
-                url = videoEntity.url,
+                urls = videoEntity.urls,
                 title = videoEntity.title,
                 description = videoEntity.description,
                 uploadedAt = videoEntity.uploadedAt,

--- a/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/client/FileApiClient.kt
+++ b/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/client/FileApiClient.kt
@@ -1,6 +1,7 @@
 package hu.bsstudio.bssweb.fileserver.client
 
-import hu.bsstudio.bssweb.fileserver.model.FileUpdate
+import hu.bsstudio.bssweb.fileserver.model.MemberFileUpdate
+import hu.bsstudio.bssweb.fileserver.model.VideoFileUpdate
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -8,14 +9,14 @@ import org.springframework.web.bind.annotation.PutMapping
 @FeignClient(name = "member", url = "\${bss.file-api.url}")
 interface FileApiClient {
     @PostMapping("/api/v1/member")
-    fun createMemberFolder(fileUpdate: FileUpdate): FileUpdate
+    fun createMemberFolder(fileUpdate: MemberFileUpdate): MemberFileUpdate
 
     @PutMapping("/api/v1/member")
-    fun updateMemberFolder(fileUpdate: FileUpdate): FileUpdate
+    fun updateMemberFolder(fileUpdate: MemberFileUpdate): MemberFileUpdate
 
     @PostMapping("/api/v1/video")
-    fun createVideoFolder(fileUpdate: FileUpdate): FileUpdate
+    fun createVideoFolder(videoFileUpdate: VideoFileUpdate): VideoFileUpdate
 
     @PutMapping("/api/v1/video")
-    fun updateVideoFolder(fileUpdate: FileUpdate): FileUpdate
+    fun updateVideoFolder(videoFileUpdate: VideoFileUpdate): VideoFileUpdate
 }

--- a/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/model/MemberFileUpdate.kt
+++ b/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/model/MemberFileUpdate.kt
@@ -2,7 +2,7 @@ package hu.bsstudio.bssweb.fileserver.model
 
 import java.util.UUID
 
-data class FileUpdate(
+data class MemberFileUpdate(
     val id: UUID,
     val url: String,
 )

--- a/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/model/VideoFileUpdate.kt
+++ b/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/model/VideoFileUpdate.kt
@@ -1,0 +1,8 @@
+package hu.bsstudio.bssweb.fileserver.model
+
+import java.util.UUID
+
+data class VideoFileUpdate(
+    val id: UUID,
+    val urls: List<String>,
+)

--- a/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/DetailedVideoEntity.kt
+++ b/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/DetailedVideoEntity.kt
@@ -1,6 +1,9 @@
 package hu.bsstudio.bssweb.video.entity
 
 import hu.bsstudio.bssweb.videocrew.entity.DetailedVideoCrewEntity
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
@@ -17,8 +20,11 @@ import java.util.UUID
 @Entity
 @Table(name = "video")
 data class DetailedVideoEntity(
-    override var url: String,
     override var title: String,
+    @Column(name = "url")
+    @ElementCollection
+    @CollectionTable(name = "video_url", joinColumns = [JoinColumn(name = "video_id")])
+    override var urls: List<String> = emptyList(),
     var description: String = "",
     override var uploadedAt: LocalDate = LocalDate.now(),
     override var visible: Boolean = false,
@@ -48,7 +54,7 @@ data class DetailedVideoEntity(
 
     override fun toString(): String =
         this::class.simpleName + "(" +
-            "url='$url', " +
+            "url='$urls', " +
             "title='$title', " +
             "description='$description', " +
             "uploadedAt=$uploadedAt, " +

--- a/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/DetailedVideoEntity.kt
+++ b/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/DetailedVideoEntity.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
 import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
@@ -22,7 +23,7 @@ import java.util.UUID
 data class DetailedVideoEntity(
     override var title: String,
     @Column(name = "url")
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "video_url", joinColumns = [JoinColumn(name = "video_id")])
     override var urls: List<String> = emptyList(),
     var description: String = "",

--- a/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/DetailedVideoEntity.kt
+++ b/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/DetailedVideoEntity.kt
@@ -55,7 +55,7 @@ data class DetailedVideoEntity(
 
     override fun toString(): String =
         this::class.simpleName + "(" +
-            "url='$urls', " +
+            "urls='$urls', " +
             "title='$title', " +
             "description='$description', " +
             "uploadedAt=$uploadedAt, " +

--- a/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/SimpleVideoEntity.kt
+++ b/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/SimpleVideoEntity.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
 import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
@@ -20,7 +21,7 @@ import java.util.UUID
 data class SimpleVideoEntity(
     override var title: String,
     @Column(name = "url")
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "video_url", joinColumns = [JoinColumn(name = "video_id")])
     override var urls: List<String> = emptyList(),
     override var uploadedAt: LocalDate = LocalDate.now(),

--- a/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/SimpleVideoEntity.kt
+++ b/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/SimpleVideoEntity.kt
@@ -1,8 +1,12 @@
 package hu.bsstudio.bssweb.video.entity
 
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
@@ -14,8 +18,11 @@ import java.util.UUID
 @Entity
 @Table(name = "video")
 data class SimpleVideoEntity(
-    override var url: String,
     override var title: String,
+    @Column(name = "url")
+    @ElementCollection
+    @CollectionTable(name = "video_url", joinColumns = [JoinColumn(name = "video_id")])
+    override var urls: List<String> = emptyList(),
     override var uploadedAt: LocalDate = LocalDate.now(),
     override var visible: Boolean = false,
 ) : VideoEntity {

--- a/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/VideoEntity.kt
+++ b/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/VideoEntity.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 @MappedSuperclass
 interface VideoEntity {
     var id: UUID
-    var url: String
+    var urls: List<String>
     var title: String
     var uploadedAt: LocalDate
     var visible: Boolean

--- a/server/data/src/main/resources/db/migration/V3__support multiple_url_alias.sql
+++ b/server/data/src/main/resources/db/migration/V3__support multiple_url_alias.sql
@@ -1,0 +1,13 @@
+CREATE TABLE video_url
+(
+    url      VARCHAR(255) PRIMARY KEY,
+    video_id UUID REFERENCES video (id)
+);
+
+-- migrate all current video.url to video_url.url
+INSERT INTO video_url (url, video_id)
+SELECT url, id
+FROM video;
+
+-- remove url from video
+ALTER TABLE video DROP COLUMN url;

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/event/repository/DetailedEventRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/event/repository/DetailedEventRepositoryTest.kt
@@ -54,7 +54,7 @@ class DetailedEventRepositoryTest(
     @Test
     internal fun `create read delete with video`() {
         val eventId = simpleEventRepository.save(SimpleEventEntity(url = URL, title = TITLE)).id
-        val video = simpleVideoRepository.save(SimpleVideoEntity(urls = listOf("url"), title = "title"))
+        val video = simpleVideoRepository.save(SimpleVideoEntity(title = "title"))
 
         eventVideoRepository.save(EventVideoEntity(eventId = eventId, videoId = video.id))
         entityManager.run {

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/event/repository/DetailedEventRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/event/repository/DetailedEventRepositoryTest.kt
@@ -54,7 +54,7 @@ class DetailedEventRepositoryTest(
     @Test
     internal fun `create read delete with video`() {
         val eventId = simpleEventRepository.save(SimpleEventEntity(url = URL, title = TITLE)).id
-        val video = simpleVideoRepository.save(SimpleVideoEntity(url = "url", title = "title"))
+        val video = simpleVideoRepository.save(SimpleVideoEntity(urls = listOf("url"), title = "title"))
 
         eventVideoRepository.save(EventVideoEntity(eventId = eventId, videoId = video.id))
         entityManager.run {

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/eventvideo/repository/EventVideoRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/eventvideo/repository/EventVideoRepositoryTest.kt
@@ -23,7 +23,7 @@ class EventVideoRepositoryTest(
 ) {
     @Test
     fun `create read delete`() {
-        val videoId = videoRepository.save(SimpleVideoEntity(url = "url", title = "title")).id
+        val videoId = videoRepository.save(SimpleVideoEntity(urls = listOf("url"), title = "title")).id
         val eventId = eventRepository.save(SimpleEventEntity(url = "url", title = "title")).id
 
         val entity = EventVideoEntity(eventId, videoId)

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/eventvideo/repository/EventVideoRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/eventvideo/repository/EventVideoRepositoryTest.kt
@@ -23,7 +23,7 @@ class EventVideoRepositoryTest(
 ) {
     @Test
     fun `create read delete`() {
-        val videoId = videoRepository.save(SimpleVideoEntity(urls = listOf("url"), title = "title")).id
+        val videoId = videoRepository.save(SimpleVideoEntity(title = "title")).id
         val eventId = eventRepository.save(SimpleEventEntity(url = "url", title = "title")).id
 
         val entity = EventVideoEntity(eventId, videoId)

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/DetailedVideoRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/DetailedVideoRepositoryTest.kt
@@ -37,7 +37,7 @@ class DetailedVideoRepositoryTest(
     internal fun `create read delete`() {
         underTest.count().shouldBeZero()
 
-        val entity = DetailedVideoEntity(url = URL, title = TITLE)
+        val entity = DetailedVideoEntity(urls = emptyList(), title = TITLE)
         val id = underTest.save(entity).id
         entityManager.run {
             flush()
@@ -62,7 +62,7 @@ class DetailedVideoRepositoryTest(
                 .let { this.memberRepository.save(it) }
                 .id
         val videoId =
-            SimpleVideoEntity(url = URL, title = TITLE)
+            SimpleVideoEntity(urls = emptyList(), title = TITLE)
                 .let { this.simpleVideoRepository.save(it) }
                 .id
         val videoCrewId = VideoCrewEntityId(videoId, "cameraman", memberId)
@@ -95,7 +95,7 @@ class DetailedVideoRepositoryTest(
         id: UUID,
         videoCrew: List<DetailedVideoCrewEntity> = emptyList(),
     ) = DetailedVideoEntity(
-        url = URL,
+        urls = emptyList(),
         title = TITLE,
         description = "",
         uploadedAt = LocalDate.now(),

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/DetailedVideoRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/DetailedVideoRepositoryTest.kt
@@ -108,7 +108,6 @@ class DetailedVideoRepositoryTest(
     }
 
     private companion object {
-        private const val URL = "szobakommando"
         private const val TITLE = "Szobakommando"
         private const val MEMBER_NAME = "Bence Csik"
         private const val MEMBER_URL = "bcsik"

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/SimpleVideoRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/SimpleVideoRepositoryTest.kt
@@ -25,7 +25,7 @@ class SimpleVideoRepositoryTest(
     fun `create read delete`() {
         underTest.count().shouldBeZero()
 
-        val entity = SimpleVideoEntity(urls = emptyList(), title = TITLE)
+        val entity = SimpleVideoEntity(title = TITLE)
         val id = underTest.save(entity).id
 
         entityManager.flush()
@@ -54,7 +54,6 @@ class SimpleVideoRepositoryTest(
     }
 
     private companion object {
-        private const val URL = "szobakommando"
         private const val TITLE = "Szobakommando"
     }
 }

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/SimpleVideoRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/SimpleVideoRepositoryTest.kt
@@ -25,7 +25,7 @@ class SimpleVideoRepositoryTest(
     fun `create read delete`() {
         underTest.count().shouldBeZero()
 
-        val entity = SimpleVideoEntity(url = URL, title = TITLE)
+        val entity = SimpleVideoEntity(urls = emptyList(), title = TITLE)
         val id = underTest.save(entity).id
 
         entityManager.flush()
@@ -34,7 +34,7 @@ class SimpleVideoRepositoryTest(
 
         val expected =
             SimpleVideoEntity(
-                url = URL,
+                urls = emptyList(),
                 title = TITLE,
                 uploadedAt = LocalDate.now(),
                 visible = false,

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/videocrew/repository/VideoCrewRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/videocrew/repository/VideoCrewRepositoryTest.kt
@@ -25,7 +25,7 @@ class VideoCrewRepositoryTest(
     @Test
     fun `create read delete`() {
         val memberId = memberRepository.save(DetailedMemberEntity(url = "url", name = "name")).id
-        val videoId = videoRepository.save(SimpleVideoEntity(url = "url", title = "title")).id
+        val videoId = videoRepository.save(SimpleVideoEntity(urls = listOf("url"), title = "title")).id
 
         val id = VideoCrewEntityId(videoId, "cameraMan", memberId)
         val entity = VideoCrewEntity(id)

--- a/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/CreateVideo.kt
+++ b/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/CreateVideo.kt
@@ -1,6 +1,5 @@
 package hu.bsstudio.bssweb.video.model
 
 data class CreateVideo(
-    val url: String,
     val title: String,
 )

--- a/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/DetailedVideo.kt
+++ b/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/DetailedVideo.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 
 data class DetailedVideo(
     val id: UUID,
-    val url: String,
+    val urls: List<String>,
     val title: String,
     val description: String,
     val uploadedAt: LocalDate,

--- a/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/UpdateVideo.kt
+++ b/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/UpdateVideo.kt
@@ -3,7 +3,7 @@ package hu.bsstudio.bssweb.video.model
 import java.time.LocalDate
 
 data class UpdateVideo(
-    val url: String,
+    val urls: List<String>,
     val title: String,
     val description: String,
     val uploadedAt: LocalDate,

--- a/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/Video.kt
+++ b/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/Video.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 
 data class Video(
     val id: UUID,
-    val url: String,
+    val urls: List<String>,
     val title: String,
     val uploadedAt: LocalDate,
     val visible: Boolean,

--- a/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/CreateVideoTest.kt
+++ b/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/CreateVideoTest.kt
@@ -26,17 +26,14 @@ internal class CreateVideoTest(
     }
 
     private companion object {
-        private const val URL = "video_url"
         private const val TITLE = "video_title"
         private val CREATE_VIDEO =
             CreateVideo(
-                url = URL,
                 title = TITLE,
             )
         private val JSON =
             """
             {
-                "url": "$URL",
                 "title": "$TITLE"
             }
             """.trimIndent()

--- a/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/DetailedVideoTest.kt
+++ b/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/DetailedVideoTest.kt
@@ -29,7 +29,7 @@ internal class DetailedVideoTest(
 
     private companion object {
         private val ID = UUID.randomUUID()
-        private const val URL = "video_url"
+        private val URLS = listOf("video_url")
         private const val TITLE = "video_title"
         private const val DESCRIPTION = "video_description"
         private val UPLOADED_AT = LocalDate.now()
@@ -37,7 +37,7 @@ internal class DetailedVideoTest(
         private val DETAILED_VIDEO =
             DetailedVideo(
                 id = ID,
-                url = URL,
+                urls = URLS,
                 title = TITLE,
                 description = DESCRIPTION,
                 uploadedAt = UPLOADED_AT,
@@ -48,7 +48,7 @@ internal class DetailedVideoTest(
             """
             {
                 "id": "$ID",
-                "url": "$URL",
+                "urls": ["${URLS[0]}"],
                 "title": "$TITLE",
                 "description": "$DESCRIPTION",
                 "uploadedAt": "$UPLOADED_AT",

--- a/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/UpdateVideoTest.kt
+++ b/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/UpdateVideoTest.kt
@@ -27,14 +27,14 @@ internal class UpdateVideoTest(
     }
 
     private companion object {
-        private const val URL = "video_url"
+        private val URLS = listOf("video_url")
         private const val TITLE = "video_title"
         private const val DESCRIPTION = "video_description"
         private val UPLOADED_AT = LocalDate.now()
         private const val VISIBLE = true
         private val UPDATE_VIDEO =
             UpdateVideo(
-                url = URL,
+                urls = URLS,
                 title = TITLE,
                 description = DESCRIPTION,
                 uploadedAt = UPLOADED_AT,
@@ -43,7 +43,7 @@ internal class UpdateVideoTest(
         private val JSON =
             """
             {
-                "url": "$URL",
+                "urls": ["${URLS[0]}"],
                 "title": "$TITLE",
                 "description": "$DESCRIPTION",
                 "uploadedAt": "$UPLOADED_AT",

--- a/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/VideoTest.kt
+++ b/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/VideoTest.kt
@@ -29,14 +29,14 @@ internal class VideoTest(
 
     private companion object {
         private val ID = UUID.randomUUID()
-        private const val URL = "video_url"
+        private val URLS = listOf("video_url")
         private const val TITLE = "video_title"
         private val UPLOADED_AT = LocalDate.now()
         private const val VISIBLE = true
         private val VIDEO =
             Video(
                 id = ID,
-                url = URL,
+                urls = URLS,
                 title = TITLE,
                 uploadedAt = UPLOADED_AT,
                 visible = VISIBLE,
@@ -45,7 +45,7 @@ internal class VideoTest(
             """
             {
                 "id": "$ID",
-                "url": "$URL",
+                "urls": ["${URLS[0]}"],
                 "title": "$TITLE",
                 "uploadedAt": "$UPLOADED_AT",
                 "visible": $VISIBLE

--- a/server/service/src/main/kotlin/hu/bsstudio/bssweb/member/service/FileUpdatingMemberService.kt
+++ b/server/service/src/main/kotlin/hu/bsstudio/bssweb/member/service/FileUpdatingMemberService.kt
@@ -1,7 +1,7 @@
 package hu.bsstudio.bssweb.member.service
 
 import hu.bsstudio.bssweb.fileserver.client.FileApiClient
-import hu.bsstudio.bssweb.fileserver.model.FileUpdate
+import hu.bsstudio.bssweb.fileserver.model.MemberFileUpdate
 import hu.bsstudio.bssweb.member.model.CreateMember
 import hu.bsstudio.bssweb.member.model.Member
 import hu.bsstudio.bssweb.member.model.UpdateMember
@@ -15,7 +15,7 @@ class FileUpdatingMemberService(private val server: MemberService, private val f
 
     override fun insertMember(createMember: CreateMember): Member {
         return this.server.insertMember(createMember)
-            .also { fileClient.createMemberFolder(FileUpdate(it.id, it.url)) }
+            .also { fileClient.createMemberFolder(MemberFileUpdate(it.id, it.url)) }
     }
 
     override fun archiveMembers(
@@ -35,7 +35,7 @@ class FileUpdatingMemberService(private val server: MemberService, private val f
     ): Optional<Member> {
         return this.server.updateMember(memberId, updateMember)
             .map {
-                fileClient.updateMemberFolder(FileUpdate(it.id, it.url))
+                fileClient.updateMemberFolder(MemberFileUpdate(it.id, it.url))
                 it
             }
     }

--- a/server/service/src/main/kotlin/hu/bsstudio/bssweb/video/mapper/VideoMapper.kt
+++ b/server/service/src/main/kotlin/hu/bsstudio/bssweb/video/mapper/VideoMapper.kt
@@ -12,7 +12,7 @@ class VideoMapper(private val videoCrewMapper: VideoCrewMapper) {
     fun entityToModel(entity: SimpleVideoEntity): Video {
         return Video(
             id = entity.id,
-            url = entity.url,
+            urls = entity.urls,
             title = entity.title,
             uploadedAt = entity.uploadedAt,
             visible = entity.visible,
@@ -22,7 +22,7 @@ class VideoMapper(private val videoCrewMapper: VideoCrewMapper) {
     fun entityToModel(entity: DetailedVideoEntity): DetailedVideo {
         return DetailedVideo(
             id = entity.id,
-            url = entity.url,
+            urls = entity.urls,
             title = entity.title,
             description = entity.description,
             uploadedAt = entity.uploadedAt,
@@ -32,14 +32,14 @@ class VideoMapper(private val videoCrewMapper: VideoCrewMapper) {
     }
 
     fun modelToEntity(model: CreateVideo): SimpleVideoEntity {
-        return SimpleVideoEntity(url = model.url, title = model.title)
+        return SimpleVideoEntity(title = model.title)
     }
 
     fun updateToEntity(
         videoEntity: DetailedVideoEntity,
         updateVideo: UpdateVideo,
     ): DetailedVideoEntity {
-        videoEntity.url = updateVideo.url
+        videoEntity.urls = updateVideo.urls
         videoEntity.title = updateVideo.title
         videoEntity.description = updateVideo.description
         videoEntity.uploadedAt = updateVideo.uploadedAt

--- a/server/service/src/main/kotlin/hu/bsstudio/bssweb/video/service/FileUpdatingVideoService.kt
+++ b/server/service/src/main/kotlin/hu/bsstudio/bssweb/video/service/FileUpdatingVideoService.kt
@@ -1,7 +1,7 @@
 package hu.bsstudio.bssweb.video.service
 
 import hu.bsstudio.bssweb.fileserver.client.FileApiClient
-import hu.bsstudio.bssweb.fileserver.model.FileUpdate
+import hu.bsstudio.bssweb.fileserver.model.VideoFileUpdate
 import hu.bsstudio.bssweb.video.model.CreateVideo
 import hu.bsstudio.bssweb.video.model.DetailedVideo
 import hu.bsstudio.bssweb.video.model.UpdateVideo
@@ -22,7 +22,7 @@ class FileUpdatingVideoService(private val service: VideoService, private val fi
 
     override fun insertVideo(createVideo: CreateVideo): Video {
         return this.service.insertVideo(createVideo)
-            .also { this.fileClient.createVideoFolder(FileUpdate(it.id, it.url)) }
+            .also { this.fileClient.createVideoFolder(VideoFileUpdate(it.id, it.urls)) }
     }
 
     override fun changeVideoVisibility(
@@ -42,7 +42,7 @@ class FileUpdatingVideoService(private val service: VideoService, private val fi
     ): Optional<DetailedVideo> {
         return this.service.updateVideo(videoId, updateVideo)
             .map {
-                this.fileClient.updateVideoFolder(FileUpdate(it.id, it.url))
+                this.fileClient.updateVideoFolder(VideoFileUpdate(it.id, it.urls))
                 it
             }
     }

--- a/server/service/src/test/kotlin/hu/bsstudio/bssweb/member/service/FileUpdatingMemberServiceTest.kt
+++ b/server/service/src/test/kotlin/hu/bsstudio/bssweb/member/service/FileUpdatingMemberServiceTest.kt
@@ -1,7 +1,7 @@
 package hu.bsstudio.bssweb.member.service
 
 import hu.bsstudio.bssweb.fileserver.client.FileApiClient
-import hu.bsstudio.bssweb.fileserver.model.FileUpdate
+import hu.bsstudio.bssweb.fileserver.model.MemberFileUpdate
 import hu.bsstudio.bssweb.member.model.CreateMember
 import hu.bsstudio.bssweb.member.model.Member
 import hu.bsstudio.bssweb.member.model.UpdateMember
@@ -120,6 +120,6 @@ internal class FileUpdatingMemberServiceTest(
         private val MEMBER_LIST = mockk<List<Member>>()
         private val CREATE_MEMBER = mockk<CreateMember>()
         private val UPDATE_MEMBER = mockk<UpdateMember>()
-        private val FILE_UPDATE = FileUpdate(MEMBER_ID, URL)
+        private val FILE_UPDATE = MemberFileUpdate(MEMBER_ID, URL)
     }
 }

--- a/server/service/src/test/kotlin/hu/bsstudio/bssweb/video/mapper/VideoMapperTest.kt
+++ b/server/service/src/test/kotlin/hu/bsstudio/bssweb/video/mapper/VideoMapperTest.kt
@@ -59,7 +59,7 @@ internal class VideoMapperTest(
 
     private companion object {
         private val VIDEO_ID = mockk<UUID>()
-        private const val URL = "url"
+        private val URLS = listOf("url")
         private const val TITLE = "title"
         private const val DESCRIPTION = "description"
         private val UPLOADED_AT = mockk<LocalDate>()
@@ -68,24 +68,24 @@ internal class VideoMapperTest(
         private val VIDEO_CREW = listOf(CREW_ENTITY)
         private val CREW_MODEL = mockk<VideoCrew>()
         private val CREW = listOf(CREW_MODEL)
-        private val VIDEO_ENTITY = SimpleVideoEntity(URL, TITLE, UPLOADED_AT, VISIBLE).apply { id = VIDEO_ID }
-        private val VIDEO = Video(VIDEO_ID, URL, TITLE, UPLOADED_AT, VISIBLE)
+        private val VIDEO_ENTITY = SimpleVideoEntity(TITLE, URLS, UPLOADED_AT, VISIBLE).apply { id = VIDEO_ID }
+        private val VIDEO = Video(VIDEO_ID, URLS, TITLE, UPLOADED_AT, VISIBLE)
         private val DETAILED_VIDEO_ENTITY =
-            DetailedVideoEntity(URL, TITLE, DESCRIPTION, UPLOADED_AT, VISIBLE).apply {
+            DetailedVideoEntity(TITLE, URLS, DESCRIPTION, UPLOADED_AT, VISIBLE).apply {
                 id = VIDEO_ID
                 videoCrew = VIDEO_CREW
             }
-        private val DETAILED_VIDEO = DetailedVideo(VIDEO_ID, URL, TITLE, DESCRIPTION, UPLOADED_AT, VISIBLE, CREW)
-        private val CREATE_VIDEO = CreateVideo(URL, TITLE)
-        private val CREATED_VIDEO_ENTITY = SimpleVideoEntity(url = URL, title = TITLE).apply { id = VIDEO_ID }
-        private const val NEW_URL = "NEW_URL"
+        private val DETAILED_VIDEO = DetailedVideo(VIDEO_ID, URLS, TITLE, DESCRIPTION, UPLOADED_AT, VISIBLE, CREW)
+        private val CREATE_VIDEO = CreateVideo(TITLE)
+        private val CREATED_VIDEO_ENTITY = SimpleVideoEntity(urls = URLS, title = TITLE).apply { id = VIDEO_ID }
+        private val NEW_URLS = listOf("newUrl")
         private const val NEW_TITLE = "NEW_TITLE"
         private const val NEW_DESCRIPTION = "NEW_DESCRIPTION"
         private val NEW_UPLOADED_AT = mockk<LocalDate>()
         private const val NEW_VISIBLE = false
-        private val UPDATE_VIDEO = UpdateVideo(NEW_URL, NEW_TITLE, NEW_DESCRIPTION, NEW_UPLOADED_AT, NEW_VISIBLE)
+        private val UPDATE_VIDEO = UpdateVideo(NEW_URLS, NEW_TITLE, NEW_DESCRIPTION, NEW_UPLOADED_AT, NEW_VISIBLE)
         private val UPDATED_VIDEO_ENTITY =
-            DetailedVideoEntity(NEW_URL, NEW_TITLE, NEW_DESCRIPTION, NEW_UPLOADED_AT, NEW_VISIBLE).apply {
+            DetailedVideoEntity(NEW_TITLE, NEW_URLS, NEW_DESCRIPTION, NEW_UPLOADED_AT, NEW_VISIBLE).apply {
                 id = VIDEO_ID
                 videoCrew = VIDEO_CREW
             }

--- a/server/service/src/test/kotlin/hu/bsstudio/bssweb/video/service/FileUpdatingVideoServiceTest.kt
+++ b/server/service/src/test/kotlin/hu/bsstudio/bssweb/video/service/FileUpdatingVideoServiceTest.kt
@@ -1,7 +1,7 @@
 package hu.bsstudio.bssweb.video.service
 
 import hu.bsstudio.bssweb.fileserver.client.FileApiClient
-import hu.bsstudio.bssweb.fileserver.model.FileUpdate
+import hu.bsstudio.bssweb.fileserver.model.VideoFileUpdate
 import hu.bsstudio.bssweb.video.model.CreateVideo
 import hu.bsstudio.bssweb.video.model.DetailedVideo
 import hu.bsstudio.bssweb.video.model.UpdateVideo
@@ -52,7 +52,7 @@ internal class FileUpdatingVideoServiceTest(
     internal fun `should insert new video`() {
         every { mockService.insertVideo(CREATE_VIDEO) } returns VIDEO
         every { VIDEO.id } returns VIDEO_ID
-        every { VIDEO.url } returns URL
+        every { VIDEO.urls } returns URLS
         every { mockClient.createVideoFolder(FILE_UPDATE) } returns FILE_UPDATE
 
         val actual = underTest.insertVideo(CREATE_VIDEO)
@@ -101,7 +101,7 @@ internal class FileUpdatingVideoServiceTest(
     internal fun `should update video`() {
         every { mockService.updateVideo(VIDEO_ID, UPDATE_VIDEO) } returns Optional.of(DETAILED_VIDEO)
         every { DETAILED_VIDEO.id } returns VIDEO_ID
-        every { DETAILED_VIDEO.url } returns URL
+        every { DETAILED_VIDEO.urls } returns URLS
         every { mockClient.updateVideoFolder(FILE_UPDATE) } returns FILE_UPDATE
 
         val actual = underTest.updateVideo(VIDEO_ID, UPDATE_VIDEO)
@@ -119,13 +119,13 @@ internal class FileUpdatingVideoServiceTest(
     private companion object {
         private val PAGEABLE = mockk<Pageable>()
         private val VIDEO_ID = mockk<UUID>()
-        private const val URL = "url"
+        private val URLS = listOf("url")
         private val VIDEO = mockk<Video>()
         private val VIDEO_LIST = mockk<List<Video>>()
         private val PAGED_VIDEOS = mockk<Page<Video>>()
         private val CREATE_VIDEO = mockk<CreateVideo>()
         private val DETAILED_VIDEO = mockk<DetailedVideo>()
         private val UPDATE_VIDEO = mockk<UpdateVideo>()
-        private val FILE_UPDATE = FileUpdate(VIDEO_ID, URL)
+        private val FILE_UPDATE = VideoFileUpdate(VIDEO_ID, URLS)
     }
 }

--- a/server/web/src/main/resources/static/open-api.yaml
+++ b/server/web/src/main/resources/static/open-api.yaml
@@ -620,15 +620,17 @@ components:
     CreateVideo:
       type: object
       properties:
-        url:
-          type: string
-          nullable: false
         title:
           type: string
           nullable: false
     UpdateVideo:
       type: object
       properties:
+        urls:
+          type: array
+          items:
+            type: string
+          nullable: false
         title:
           type: string
           nullable: false
@@ -651,8 +653,10 @@ components:
         id:
           type: string
           nullable: false
-        url:
-          type: string
+        urls:
+          type: array
+          items:
+            type: string
           nullable: false
         title:
           type: string

--- a/server/web/src/test/kotlin/hu/bsstudio/bssweb/video/controller/VideoControllerTest.kt
+++ b/server/web/src/test/kotlin/hu/bsstudio/bssweb/video/controller/VideoControllerTest.kt
@@ -168,18 +168,18 @@ internal class VideoControllerTest(
         private const val PASSWORD = "password"
         private val PAGEABLE: Pageable = PageRequest.of(0, 20)
         private val VIDEO_ID = UUID.randomUUID()
-        private const val URL = "url"
+        private val URLS = listOf("url")
         private const val TITLE = "title"
         private val UPLOADED_AT = LocalDate.now()
         private const val VISIBLE = false
         private const val DESCRIPTION = "description"
-        private val VIDEO = Video(id = VIDEO_ID, url = URL, title = TITLE, uploadedAt = UPLOADED_AT, visible = VISIBLE)
+        private val VIDEO = Video(id = VIDEO_ID, urls = URLS, title = TITLE, uploadedAt = UPLOADED_AT, visible = VISIBLE)
         private val PAGED_VIDEOS = PageImpl(listOf(VIDEO), PAGEABLE, 1)
-        private val CREATE_VIDEO = CreateVideo(url = URL, title = TITLE)
+        private val CREATE_VIDEO = CreateVideo(title = TITLE)
         private val DETAILED_VIDEO =
             DetailedVideo(
                 id = VIDEO_ID,
-                url = URL,
+                urls = URLS,
                 title = TITLE,
                 description = DESCRIPTION,
                 uploadedAt = UPLOADED_AT,
@@ -187,6 +187,6 @@ internal class VideoControllerTest(
                 crew = listOf(),
             )
         private val UPDATE_VIDEO =
-            UpdateVideo(url = URL, title = TITLE, description = DESCRIPTION, uploadedAt = UPLOADED_AT, visible = VISIBLE)
+            UpdateVideo(urls = URLS, title = TITLE, description = DESCRIPTION, uploadedAt = UPLOADED_AT, visible = VISIBLE)
     }
 }

--- a/server/web/src/test/kotlin/hu/bsstudio/bssweb/videocrew/controller/VideoCrewControllerTest.kt
+++ b/server/web/src/test/kotlin/hu/bsstudio/bssweb/videocrew/controller/VideoCrewControllerTest.kt
@@ -114,7 +114,7 @@ internal class VideoCrewControllerTest(
         private val DETAILED_VIDEO =
             DetailedVideo(
                 id = VIDEO_ID,
-                url = "url",
+                urls = listOf("url"),
                 title = "title",
                 description = "description",
                 uploadedAt = LocalDate.now(),

--- a/stubs/file-api/default-mapping.json
+++ b/stubs/file-api/default-mapping.json
@@ -7,9 +7,6 @@
         "bodyPatterns": [
           {
             "matchesJsonPath": "$.id"
-          },
-          {
-            "matchesJsonPath": "$.urls"
           }
         ]
       },

--- a/stubs/file-api/default-mapping.json
+++ b/stubs/file-api/default-mapping.json
@@ -9,7 +9,7 @@
             "matchesJsonPath": "$.id"
           },
           {
-            "matchesJsonPath": "$.url"
+            "matchesJsonPath": "$.urls"
           }
         ]
       },
@@ -20,7 +20,7 @@
         },
         "jsonBody": {
           "id": "01234567-0123-0123-0123-0123456789ab",
-          "url": "url"
+          "urls": ["url"]
         }
       }
     },
@@ -57,7 +57,7 @@
             "matchesJsonPath": "$.id"
           },
           {
-            "matchesJsonPath": "$.url"
+            "matchesJsonPath": "$.urls"
           }
         ]
       },
@@ -68,7 +68,7 @@
         },
         "jsonBody": {
           "id": "01234567-0123-0123-0123-0123456789ab",
-          "url": "url"
+          "urls": ["url"]
         }
       }
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced support for multiple URL aliases for videos, enhancing flexibility in video management.
- **Refactor**
	- Updated video-related entities, models, and tests to handle a list of URLs (`urls`) instead of a single URL (`url`), aligning with the new multiple URLs feature.
- **Chores**
	- Improved Dockerfile by ensuring `gradle.properties` is included in the build stage for more efficient configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->