### PR TITLE
Feature: update video with shooting date range

### DIFF
--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/AddVideoToEventIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/eventvideo/integration/AddVideoToEventIntegrationTest.kt
@@ -41,7 +41,8 @@ class AddVideoToEventIntegrationTest(
                         id = videoEntity.id,
                         urls = videoEntity.urls,
                         title = videoEntity.title,
-                        uploadedAt = videoEntity.uploadedAt,
+                        shootingDateStart = videoEntity.shootingDateStart,
+                        shootingDateEnd = videoEntity.shootingDateEnd,
                         visible = videoEntity.visible
                     )
                 )

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/CreateVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/CreateVideoIntegrationTest.kt
@@ -32,7 +32,8 @@ class CreateVideoIntegrationTest(
                 urls = emptyList(),
                 title = CREATE_VIDEO.title,
                 visible = false,
-                uploadedAt = LocalDate.now()
+                shootingDateStart = LocalDate.now(),
+                shootingDateEnd = LocalDate.now()
             )
             headers.location!! shouldBeEqual java.net.URI.create("$url/api/v1/video/${actual.body!!.id}")
         }

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadAllPageableVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadAllPageableVideoIntegrationTest.kt
@@ -38,14 +38,16 @@ class ReadAllPageableVideoIntegrationTest(
                     id = entity0.id,
                     urls = listOf("url0"),
                     title = "title0",
-                    uploadedAt = LocalDate.now(),
+                    shootingDateStart = LocalDate.now(),
+                    shootingDateEnd = LocalDate.now(),
                     visible = false
                 ),
                 Video(
                     id = entity1.id,
                     urls = listOf("url1"),
                     title = "title1",
-                    uploadedAt = LocalDate.now(),
+                    shootingDateStart = LocalDate.now(),
+                    shootingDateEnd = LocalDate.now(),
                     visible = false
                 )
             )
@@ -57,14 +59,16 @@ class ReadAllPageableVideoIntegrationTest(
                     id = entity2.id,
                     urls = listOf("url2"),
                     title = "title2",
-                    uploadedAt = LocalDate.now(),
+                    shootingDateStart = LocalDate.now(),
+                    shootingDateEnd = LocalDate.now(),
                     visible = false
                 ),
                 Video(
                     id = entity3.id,
                     urls = listOf("url3"),
                     title = "title3",
-                    uploadedAt = LocalDate.now(),
+                    shootingDateStart = LocalDate.now(),
+                    shootingDateEnd = LocalDate.now(),
                     visible = false
                 )
             )

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadAllVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadAllVideoIntegrationTest.kt
@@ -39,7 +39,8 @@ class ReadAllVideoIntegrationTest(
                     urls = emptyList(),
                     title = TITLE,
                     visible = false,
-                    uploadedAt = LocalDate.now()
+                    shootingDateStart = LocalDate.now(),
+                    shootingDateEnd = LocalDate.now(),
                 )
             )
             statusCode shouldBeEqual org.springframework.http.HttpStatusCode.valueOf(200)

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/ReadVideoIntegrationTest.kt
@@ -39,7 +39,8 @@ class ReadVideoIntegrationTest(
                 title = TITLE,
                 description = "",
                 visible = false,
-                uploadedAt = LocalDate.now(),
+                shootingDateStart = LocalDate.now(),
+                shootingDateEnd = LocalDate.now(),
                 crew = listOf()
             )
         }

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/UpdateVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/UpdateVideoIntegrationTest.kt
@@ -44,9 +44,9 @@ class UpdateVideoIntegrationTest(
     fun `it should return 500 when dateTo is before dateFrom`() {
         val entity = this.videoRepository.save(DetailedVideoEntity(title = "title"))
 
-        val updateEvent = UPDATE_VIDEO.copy(shootingDateEnd = LocalDate.EPOCH)
+        val updateVideo = UPDATE_VIDEO.copy(shootingDateEnd = LocalDate.EPOCH)
         shouldThrow<FeignException.InternalServerError> {
-            client.updateVideo(entity.id, updateEvent)
+            client.updateVideo(entity.id, updateVideo)
         }
     }
 

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/UpdateVideoIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/video/integration/UpdateVideoIntegrationTest.kt
@@ -33,9 +33,20 @@ class UpdateVideoIntegrationTest(
                 title = UPDATE_VIDEO.title,
                 description = UPDATE_VIDEO.description,
                 visible = UPDATE_VIDEO.visible,
-                uploadedAt = UPDATE_VIDEO.uploadedAt,
+                shootingDateStart = UPDATE_VIDEO.shootingDateStart,
+                shootingDateEnd = UPDATE_VIDEO.shootingDateEnd,
                 crew = listOf()
             )
+        }
+    }
+
+    @Test
+    fun `it should return 500 when dateTo is before dateFrom`() {
+        val entity = this.videoRepository.save(DetailedVideoEntity(title = "title"))
+
+        val updateEvent = UPDATE_VIDEO.copy(shootingDateEnd = LocalDate.EPOCH)
+        shouldThrow<FeignException.InternalServerError> {
+            client.updateVideo(entity.id, updateEvent)
         }
     }
 
@@ -55,7 +66,8 @@ class UpdateVideoIntegrationTest(
             title = "updatedTitle",
             description = "updatedDescription",
             visible = true,
-            uploadedAt = LocalDate.of(2023, 1, 1)
+            shootingDateStart = LocalDate.of(2023, 1, 1),
+            shootingDateEnd = LocalDate.of(2023, 1, 2)
         )
     }
 }

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/videocrew/integration/AddVideoCrewIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/videocrew/integration/AddVideoCrewIntegrationTest.kt
@@ -31,7 +31,8 @@ class AddVideoCrewIntegrationTest(
                 urls = videoEntity.urls,
                 title = videoEntity.title,
                 description = videoEntity.description,
-                uploadedAt = videoEntity.uploadedAt,
+                shootingDateStart = videoEntity.shootingDateStart,
+                shootingDateEnd = videoEntity.shootingDateEnd,
                 visible = videoEntity.visible,
                 crew = listOf(
                     VideoCrew(

--- a/integration/src/intTest/kotlin/hu/bsstudio/bssweb/videocrew/integration/RemoveVideoCrewIntegrationTest.kt
+++ b/integration/src/intTest/kotlin/hu/bsstudio/bssweb/videocrew/integration/RemoveVideoCrewIntegrationTest.kt
@@ -32,7 +32,8 @@ class RemoveVideoCrewIntegrationTest(
                 urls = videoEntity.urls,
                 title = videoEntity.title,
                 description = videoEntity.description,
-                uploadedAt = videoEntity.uploadedAt,
+                shootingDateStart = videoEntity.shootingDateStart,
+                shootingDateEnd = videoEntity.shootingDateEnd,
                 visible = videoEntity.visible,
                 crew = listOf()
             )

--- a/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/DetailedVideoEntity.kt
+++ b/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/DetailedVideoEntity.kt
@@ -27,7 +27,8 @@ data class DetailedVideoEntity(
     @CollectionTable(name = "video_url", joinColumns = [JoinColumn(name = "video_id")])
     override var urls: List<String> = emptyList(),
     var description: String = "",
-    override var uploadedAt: LocalDate = LocalDate.now(),
+    override var shootingDateStart: LocalDate = LocalDate.now(),
+    override var shootingDateEnd: LocalDate = LocalDate.now(),
     override var visible: Boolean = false,
 ) : VideoEntity {
     @Id
@@ -58,7 +59,8 @@ data class DetailedVideoEntity(
             "urls='$urls', " +
             "title='$title', " +
             "description='$description', " +
-            "uploadedAt=$uploadedAt, " +
+            "shootingDateStart=$shootingDateStart, " +
+            "shootingDateEnd=$shootingDateEnd, " +
             "visible=$visible, " +
             "id=$id" +
             ")"

--- a/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/SimpleVideoEntity.kt
+++ b/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/SimpleVideoEntity.kt
@@ -24,7 +24,8 @@ data class SimpleVideoEntity(
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "video_url", joinColumns = [JoinColumn(name = "video_id")])
     override var urls: List<String> = emptyList(),
-    override var uploadedAt: LocalDate = LocalDate.now(),
+    override var shootingDateStart: LocalDate = LocalDate.now(),
+    override var shootingDateEnd: LocalDate = LocalDate.now(),
     override var visible: Boolean = false,
 ) : VideoEntity {
     @Id

--- a/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/VideoEntity.kt
+++ b/server/data/src/main/kotlin/hu/bsstudio/bssweb/video/entity/VideoEntity.kt
@@ -12,7 +12,8 @@ interface VideoEntity {
     var id: UUID
     var urls: List<String>
     var title: String
-    var uploadedAt: LocalDate
+    var shootingDateStart: LocalDate
+    var shootingDateEnd: LocalDate
     var visible: Boolean
 
     @set:CreationTimestamp

--- a/server/data/src/main/resources/db/migration/V6__support_video_date_range.sql
+++ b/server/data/src/main/resources/db/migration/V6__support_video_date_range.sql
@@ -9,4 +9,4 @@ ALTER TABLE video
 -- add constraint to ensure date_to is not before date_from
 ALTER TABLE video
     ADD CONSTRAINT date_to_not_before_date_from
-    CHECK (shooting_date_start >= shooting_date_end);
+    CHECK (shooting_date_end >= video.shooting_date_start);

--- a/server/data/src/main/resources/db/migration/V6__support_video_date_range.sql
+++ b/server/data/src/main/resources/db/migration/V6__support_video_date_range.sql
@@ -1,0 +1,12 @@
+-- update event.date column to date_from
+ALTER TABLE video
+    RENAME COLUMN uploaded_at TO shooting_date_start;
+
+-- add date_to column, default to date_from
+ALTER TABLE video
+    ADD COLUMN shooting_date_end DATE NOT NULL DEFAULT current_date;
+
+-- add constraint to ensure date_to is not before date_from
+ALTER TABLE video
+    ADD CONSTRAINT date_to_not_before_date_from
+    CHECK (shooting_date_start >= shooting_date_end);

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/DetailedVideoRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/DetailedVideoRepositoryTest.kt
@@ -98,7 +98,8 @@ class DetailedVideoRepositoryTest(
         urls = emptyList(),
         title = TITLE,
         description = "",
-        uploadedAt = LocalDate.now(),
+        shootingDateStart = LocalDate.now(),
+        shootingDateEnd = LocalDate.now(),
         visible = false,
     ).apply {
         this.id = id

--- a/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/SimpleVideoRepositoryTest.kt
+++ b/server/data/src/test/kotlin/hu/bsstudio/bssweb/video/repository/SimpleVideoRepositoryTest.kt
@@ -36,7 +36,8 @@ class SimpleVideoRepositoryTest(
             SimpleVideoEntity(
                 urls = emptyList(),
                 title = TITLE,
-                uploadedAt = LocalDate.now(),
+                shootingDateStart = LocalDate.now(),
+                shootingDateEnd = LocalDate.now(),
                 visible = false,
             ).apply {
                 this.id = id

--- a/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/DetailedVideo.kt
+++ b/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/DetailedVideo.kt
@@ -9,7 +9,8 @@ data class DetailedVideo(
     val urls: List<String>,
     val title: String,
     val description: String,
-    val uploadedAt: LocalDate,
+    val shootingDateStart: LocalDate,
+    val shootingDateEnd: LocalDate,
     val visible: Boolean,
     val crew: List<VideoCrew>,
 )

--- a/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/UpdateVideo.kt
+++ b/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/UpdateVideo.kt
@@ -6,6 +6,7 @@ data class UpdateVideo(
     val urls: List<String>,
     val title: String,
     val description: String,
-    val uploadedAt: LocalDate,
+    val shootingDateStart: LocalDate,
+    val shootingDateEnd: LocalDate,
     val visible: Boolean,
 )

--- a/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/Video.kt
+++ b/server/model/src/main/kotlin/hu/bsstudio/bssweb/video/model/Video.kt
@@ -7,6 +7,7 @@ data class Video(
     val id: UUID,
     val urls: List<String>,
     val title: String,
-    val uploadedAt: LocalDate,
+    val shootingDateStart: LocalDate,
+    val shootingDateEnd: LocalDate,
     val visible: Boolean,
 )

--- a/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/DetailedVideoTest.kt
+++ b/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/DetailedVideoTest.kt
@@ -32,7 +32,8 @@ internal class DetailedVideoTest(
         private val URLS = listOf("video_url")
         private const val TITLE = "video_title"
         private const val DESCRIPTION = "video_description"
-        private val UPLOADED_AT = LocalDate.now()
+        private val SHOOTING_DATE_START = LocalDate.EPOCH
+        private val SHOOTING_DATE_END = LocalDate.MAX
         private const val VISIBLE = true
         private val DETAILED_VIDEO =
             DetailedVideo(
@@ -40,7 +41,8 @@ internal class DetailedVideoTest(
                 urls = URLS,
                 title = TITLE,
                 description = DESCRIPTION,
-                uploadedAt = UPLOADED_AT,
+                shootingDateStart = SHOOTING_DATE_START,
+                shootingDateEnd = SHOOTING_DATE_END,
                 visible = VISIBLE,
                 crew = listOf(),
             )
@@ -51,7 +53,8 @@ internal class DetailedVideoTest(
                 "urls": ["${URLS[0]}"],
                 "title": "$TITLE",
                 "description": "$DESCRIPTION",
-                "uploadedAt": "$UPLOADED_AT",
+                "shootingDateStart": "$SHOOTING_DATE_START",
+                "shootingDateEnd": "$SHOOTING_DATE_END",
                 "visible": $VISIBLE,
                 "crew": []
             }

--- a/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/UpdateVideoTest.kt
+++ b/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/UpdateVideoTest.kt
@@ -30,14 +30,16 @@ internal class UpdateVideoTest(
         private val URLS = listOf("video_url")
         private const val TITLE = "video_title"
         private const val DESCRIPTION = "video_description"
-        private val UPLOADED_AT = LocalDate.now()
+        private val SHOOTING_DATE_START = LocalDate.EPOCH
+        private val SHOOTING_DATE_END = LocalDate.MAX
         private const val VISIBLE = true
         private val UPDATE_VIDEO =
             UpdateVideo(
                 urls = URLS,
                 title = TITLE,
                 description = DESCRIPTION,
-                uploadedAt = UPLOADED_AT,
+                shootingDateStart = SHOOTING_DATE_START,
+                shootingDateEnd = SHOOTING_DATE_END,
                 visible = VISIBLE,
             )
         private val JSON =
@@ -46,7 +48,8 @@ internal class UpdateVideoTest(
                 "urls": ["${URLS[0]}"],
                 "title": "$TITLE",
                 "description": "$DESCRIPTION",
-                "uploadedAt": "$UPLOADED_AT",
+                "shootingDateStart": "$SHOOTING_DATE_START",
+                "shootingDateEnd": "$SHOOTING_DATE_END",
                 "visible": $VISIBLE
             }
             """.trimIndent()

--- a/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/VideoTest.kt
+++ b/server/model/src/test/kotlin/hu/bsstudio/bssweb/video/model/VideoTest.kt
@@ -31,14 +31,16 @@ internal class VideoTest(
         private val ID = UUID.randomUUID()
         private val URLS = listOf("video_url")
         private const val TITLE = "video_title"
-        private val UPLOADED_AT = LocalDate.now()
+        private val SHOOTING_DATE_START = LocalDate.EPOCH
+        private val SHOOTING_DATE_END = LocalDate.MAX
         private const val VISIBLE = true
         private val VIDEO =
             Video(
                 id = ID,
                 urls = URLS,
                 title = TITLE,
-                uploadedAt = UPLOADED_AT,
+                shootingDateStart = SHOOTING_DATE_START,
+                shootingDateEnd = SHOOTING_DATE_END,
                 visible = VISIBLE,
             )
         private val JSON =
@@ -47,7 +49,8 @@ internal class VideoTest(
                 "id": "$ID",
                 "urls": ["${URLS[0]}"],
                 "title": "$TITLE",
-                "uploadedAt": "$UPLOADED_AT",
+                "shootingDateStart": "$SHOOTING_DATE_START",
+                "shootingDateEnd": "$SHOOTING_DATE_END",
                 "visible": $VISIBLE
             }
             """.trimIndent()

--- a/server/service/src/main/kotlin/hu/bsstudio/bssweb/video/mapper/VideoMapper.kt
+++ b/server/service/src/main/kotlin/hu/bsstudio/bssweb/video/mapper/VideoMapper.kt
@@ -14,7 +14,8 @@ class VideoMapper(private val videoCrewMapper: VideoCrewMapper) {
             id = entity.id,
             urls = entity.urls,
             title = entity.title,
-            uploadedAt = entity.uploadedAt,
+            shootingDateStart = entity.shootingDateStart,
+            shootingDateEnd = entity.shootingDateEnd,
             visible = entity.visible,
         )
     }
@@ -25,7 +26,8 @@ class VideoMapper(private val videoCrewMapper: VideoCrewMapper) {
             urls = entity.urls,
             title = entity.title,
             description = entity.description,
-            uploadedAt = entity.uploadedAt,
+            shootingDateStart = entity.shootingDateStart,
+            shootingDateEnd = entity.shootingDateEnd,
             visible = entity.visible,
             crew = entity.videoCrew.map(videoCrewMapper::entityToModel),
         )
@@ -42,7 +44,8 @@ class VideoMapper(private val videoCrewMapper: VideoCrewMapper) {
         videoEntity.urls = updateVideo.urls
         videoEntity.title = updateVideo.title
         videoEntity.description = updateVideo.description
-        videoEntity.uploadedAt = updateVideo.uploadedAt
+        videoEntity.shootingDateStart = updateVideo.shootingDateStart
+        videoEntity.shootingDateEnd = updateVideo.shootingDateEnd
         videoEntity.visible = updateVideo.visible
         return videoEntity
     }

--- a/server/service/src/test/kotlin/hu/bsstudio/bssweb/video/mapper/VideoMapperTest.kt
+++ b/server/service/src/test/kotlin/hu/bsstudio/bssweb/video/mapper/VideoMapperTest.kt
@@ -62,30 +62,34 @@ internal class VideoMapperTest(
         private val URLS = listOf("url")
         private const val TITLE = "title"
         private const val DESCRIPTION = "description"
-        private val UPLOADED_AT = mockk<LocalDate>()
+        private val SHOOTING_DATE_START = mockk<LocalDate>()
+        private val SHOOTING_DATE_END = mockk<LocalDate>()
         private const val VISIBLE = true
         private val CREW_ENTITY = mockk<DetailedVideoCrewEntity>()
         private val VIDEO_CREW = listOf(CREW_ENTITY)
         private val CREW_MODEL = mockk<VideoCrew>()
         private val CREW = listOf(CREW_MODEL)
-        private val VIDEO_ENTITY = SimpleVideoEntity(TITLE, URLS, UPLOADED_AT, VISIBLE).apply { id = VIDEO_ID }
-        private val VIDEO = Video(VIDEO_ID, URLS, TITLE, UPLOADED_AT, VISIBLE)
+        private val VIDEO_ENTITY = SimpleVideoEntity(TITLE, URLS, SHOOTING_DATE_START, SHOOTING_DATE_END, VISIBLE).apply { id = VIDEO_ID }
+        private val VIDEO = Video(VIDEO_ID, URLS, TITLE, SHOOTING_DATE_START, SHOOTING_DATE_END, VISIBLE)
         private val DETAILED_VIDEO_ENTITY =
-            DetailedVideoEntity(TITLE, URLS, DESCRIPTION, UPLOADED_AT, VISIBLE).apply {
+            DetailedVideoEntity(TITLE, URLS, DESCRIPTION, SHOOTING_DATE_START, SHOOTING_DATE_END, VISIBLE).apply {
                 id = VIDEO_ID
                 videoCrew = VIDEO_CREW
             }
-        private val DETAILED_VIDEO = DetailedVideo(VIDEO_ID, URLS, TITLE, DESCRIPTION, UPLOADED_AT, VISIBLE, CREW)
+        private val DETAILED_VIDEO =
+            DetailedVideo(VIDEO_ID, URLS, TITLE, DESCRIPTION, SHOOTING_DATE_START, SHOOTING_DATE_END, VISIBLE, CREW)
         private val CREATE_VIDEO = CreateVideo(TITLE)
         private val CREATED_VIDEO_ENTITY = SimpleVideoEntity(urls = URLS, title = TITLE).apply { id = VIDEO_ID }
         private val NEW_URLS = listOf("newUrl")
         private const val NEW_TITLE = "NEW_TITLE"
         private const val NEW_DESCRIPTION = "NEW_DESCRIPTION"
-        private val NEW_UPLOADED_AT = mockk<LocalDate>()
+        private val NEW_SHOOTING_DATE_START = mockk<LocalDate>()
+        private val NEW_SHOOTING_DATE_END = mockk<LocalDate>()
         private const val NEW_VISIBLE = false
-        private val UPDATE_VIDEO = UpdateVideo(NEW_URLS, NEW_TITLE, NEW_DESCRIPTION, NEW_UPLOADED_AT, NEW_VISIBLE)
+        private val UPDATE_VIDEO =
+            UpdateVideo(NEW_URLS, NEW_TITLE, NEW_DESCRIPTION, NEW_SHOOTING_DATE_START, NEW_SHOOTING_DATE_END, NEW_VISIBLE)
         private val UPDATED_VIDEO_ENTITY =
-            DetailedVideoEntity(NEW_TITLE, NEW_URLS, NEW_DESCRIPTION, NEW_UPLOADED_AT, NEW_VISIBLE).apply {
+            DetailedVideoEntity(NEW_TITLE, NEW_URLS, NEW_DESCRIPTION, NEW_SHOOTING_DATE_START, NEW_SHOOTING_DATE_END, NEW_VISIBLE).apply {
                 id = VIDEO_ID
                 videoCrew = VIDEO_CREW
             }

--- a/server/web/src/test/kotlin/hu/bsstudio/bssweb/video/controller/VideoControllerTest.kt
+++ b/server/web/src/test/kotlin/hu/bsstudio/bssweb/video/controller/VideoControllerTest.kt
@@ -170,10 +170,19 @@ internal class VideoControllerTest(
         private val VIDEO_ID = UUID.randomUUID()
         private val URLS = listOf("url")
         private const val TITLE = "title"
-        private val UPLOADED_AT = LocalDate.now()
+        private val SHOOTING_DATE_START = LocalDate.EPOCH
+        private val SHOOTING_DATE_END = LocalDate.MAX
         private const val VISIBLE = false
         private const val DESCRIPTION = "description"
-        private val VIDEO = Video(id = VIDEO_ID, urls = URLS, title = TITLE, uploadedAt = UPLOADED_AT, visible = VISIBLE)
+        private val VIDEO =
+            Video(
+                id = VIDEO_ID,
+                urls = URLS,
+                title = TITLE,
+                shootingDateStart = SHOOTING_DATE_START,
+                shootingDateEnd = SHOOTING_DATE_END,
+                visible = VISIBLE,
+            )
         private val PAGED_VIDEOS = PageImpl(listOf(VIDEO), PAGEABLE, 1)
         private val CREATE_VIDEO = CreateVideo(title = TITLE)
         private val DETAILED_VIDEO =
@@ -182,11 +191,19 @@ internal class VideoControllerTest(
                 urls = URLS,
                 title = TITLE,
                 description = DESCRIPTION,
-                uploadedAt = UPLOADED_AT,
+                shootingDateStart = SHOOTING_DATE_START,
+                shootingDateEnd = SHOOTING_DATE_END,
                 visible = VISIBLE,
                 crew = listOf(),
             )
         private val UPDATE_VIDEO =
-            UpdateVideo(urls = URLS, title = TITLE, description = DESCRIPTION, uploadedAt = UPLOADED_AT, visible = VISIBLE)
+            UpdateVideo(
+                urls = URLS,
+                title = TITLE,
+                description = DESCRIPTION,
+                shootingDateStart = SHOOTING_DATE_START,
+                shootingDateEnd = SHOOTING_DATE_END,
+                visible = VISIBLE,
+            )
     }
 }

--- a/server/web/src/test/kotlin/hu/bsstudio/bssweb/videocrew/controller/VideoCrewControllerTest.kt
+++ b/server/web/src/test/kotlin/hu/bsstudio/bssweb/videocrew/controller/VideoCrewControllerTest.kt
@@ -117,7 +117,8 @@ internal class VideoCrewControllerTest(
                 urls = listOf("url"),
                 title = "title",
                 description = "description",
-                uploadedAt = LocalDate.now(),
+                shootingDateStart = LocalDate.now(),
+                shootingDateEnd = LocalDate.now(),
                 visible = false,
                 crew = listOf(),
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Users can now specify a date range (`shootingDateStart` and `shootingDateEnd`) for videos, replacing the single `uploadedAt` date.

- **Bug Fixes**
    - Added validation to ensure `shootingDateEnd` is after `shootingDateStart`.

- **Refactor**
    - Updated video-related entities, models, and tests to accommodate the new date range feature.

- **Database Changes**
    - Implemented a new database migration to support video date ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->