### PR TITLE
Add compiler warnings for Java and Kotlin tasks

### DIFF
--- a/buildSrc/src/main/kotlin/java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-conventions.gradle.kts
@@ -12,3 +12,7 @@ configurations {
         extendsFrom(configurations.annotationProcessor.get())
     }
 }
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.add("-Xlint:all")
+}

--- a/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-library-conventions.gradle.kts
@@ -12,3 +12,7 @@ configurations {
         extendsFrom(configurations.annotationProcessor.get())
     }
 }
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.add("-Xlint:all")
+}

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict")
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+        allWarningsAsErrors = true
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
     }
 }


### PR DESCRIPTION
- Updated JavaCompile tasks to include `-Xlint:all` for enhanced warning visibility.
- Modified KotlinCompile tasks to set `allWarningsAsErrors` to true, ensuring all warnings are treated as errors during compilation.