### PR TITLE
fix: update release.yml to add permissions for GitHub release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -25,4 +29,5 @@ jobs:
 
       - run: semantic-release
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}


### PR DESCRIPTION
Automatic releases didn't work without a PAT:
https://github.com/semantic-release/github?tab=readme-ov-file#configuration