### PR TITLE
feat: remove Feign and implement Spring RestClient for API communication

### DIFF
--- a/buildSrc/src/main/kotlin/hu/bsstudio/gradle/DependencyManagementPlugin.kt
+++ b/buildSrc/src/main/kotlin/hu/bsstudio/gradle/DependencyManagementPlugin.kt
@@ -13,7 +13,6 @@ class DependencyManagementPlugin : Plugin<Project> {
 
         project.dependencies {
             add("implementation", platform(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES))
-            add("implementation", platform("org.springframework.cloud:spring-cloud-dependencies:2025.1.2"))
         }
     }
 }

--- a/client/README.md
+++ b/client/README.md
@@ -1,9 +1,8 @@
 # The client module
 
-This module stores exposes some interfaces to easily interact with the backend services.
-It uses Spring Cloud OpenFeign to make the requests.
+This module exposes some interfaces to easily interact with the backend service.
 
-The `BssFeignConfig` class will expose beans for each controller in the backend services.
+The `BssWebAdminBackendClientConfig` class will expose beans for each controller in the backend service.
 
 There are some properties to control authorisation.
 Refer to the [additional-spring-configuration-metadata.json][metadata-json]

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 
 dependencies {
     api(project(":server:operation"))
-    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     implementation("org.springframework:spring-context")
     implementation("org.springframework:spring-web")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - postgres
     environment:
       bss.file-api.url: "http://mock-file-api:8080"
+      bss.file-api.username: "username"
+      bss.file-api.password: "password"
       spring.security.oauth2.resourceserver.opaquetoken.introspection-uri: "http://mock-oidc:8080/o/introspect"
       spring.security.oauth2.resourceserver.opaquetoken.client-id: client-id
       spring.security.oauth2.resourceserver.opaquetoken.client-secret: client-secret

--- a/docker/wiremock/stubs/file-api/default-mapping.json
+++ b/docker/wiremock/stubs/file-api/default-mapping.json
@@ -4,6 +4,10 @@
       "request": {
         "method": "POST",
         "url": "/api/v1/video",
+        "basicAuthCredentials": {
+          "username": "username",
+          "password": "password"
+        },
         "bodyPatterns": [
           {
             "matchesJsonPath": "$.id"
@@ -25,6 +29,10 @@
       "request": {
         "method": "POST",
         "url": "/api/v1/member",
+        "basicAuthCredentials": {
+          "username": "username",
+          "password": "password"
+        },
         "bodyPatterns": [
           {
             "matchesJsonPath": "$.id"
@@ -49,6 +57,10 @@
       "request": {
         "method": "PUT",
         "url": "/api/v1/video",
+        "basicAuthCredentials": {
+          "username": "username",
+          "password": "password"
+        },
         "bodyPatterns": [
           {
             "matchesJsonPath": "$.id"
@@ -73,6 +85,10 @@
       "request": {
         "method": "PUT",
         "url": "/api/v1/member",
+        "basicAuthCredentials": {
+          "username": "username",
+          "password": "password"
+        },
         "bodyPatterns": [
           {
             "matchesJsonPath": "$.id"

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
         exclude("org.springframework.boot", "spring-boot-starter-flyway")
     }
     integrationTestImplementation(project(":client"))
-    integrationTestImplementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     integrationTestImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
     integrationTestImplementation("org.springframework.boot:spring-boot-starter-json")
     integrationTestImplementation("org.springframework.boot:spring-boot-data-jpa-test")

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
         exclude("org.springframework.boot", "spring-boot-starter-flyway")
     }
     integrationTestImplementation(project(":client"))
+    integrationTestImplementation("org.springframework:spring-web")
     integrationTestImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
     integrationTestImplementation("org.springframework.boot:spring-boot-starter-json")
     integrationTestImplementation("org.springframework.boot:spring-boot-data-jpa-test")

--- a/server/client/build.gradle.kts
+++ b/server/client/build.gradle.kts
@@ -9,17 +9,9 @@ plugins {
 }
 
 dependencies {
-    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+    implementation("org.springframework:spring-context")
+    implementation("org.springframework:spring-web")
     implementation("tools.jackson.module:jackson-module-kotlin")
     testImplementation(libs.kotestAssertionsJson)
     testImplementation("org.springframework.boot:spring-boot-starter-jackson-test")
-
-    constraints {
-        implementation("commons-fileupload:commons-fileupload") {
-            version {
-                require("[1.6, 2.0[")
-                because("CVE-2025-48976")
-            }
-        }
-    }
 }

--- a/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/client/FileApiClient.kt
+++ b/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/client/FileApiClient.kt
@@ -10,14 +10,22 @@ import org.springframework.web.service.annotation.PutExchange
 @HttpExchange("/api/v1")
 interface FileApiClient {
     @PostExchange("/member")
-    fun createMemberFolder(@RequestBody fileUpdate: MemberFileUpdate): MemberFileUpdate
+    fun createMemberFolder(
+        @RequestBody fileUpdate: MemberFileUpdate,
+    ): MemberFileUpdate
 
     @PutExchange("/member")
-    fun updateMemberFolder(@RequestBody fileUpdate: MemberFileUpdate): MemberFileUpdate
+    fun updateMemberFolder(
+        @RequestBody fileUpdate: MemberFileUpdate,
+    ): MemberFileUpdate
 
     @PostExchange("/video")
-    fun createVideoFolder(@RequestBody videoFileUpdate: VideoFileUpdate): VideoFileUpdate
+    fun createVideoFolder(
+        @RequestBody videoFileUpdate: VideoFileUpdate,
+    ): VideoFileUpdate
 
     @PutExchange("/video")
-    fun updateVideoFolder(@RequestBody videoFileUpdate: VideoFileUpdate): VideoFileUpdate
+    fun updateVideoFolder(
+        @RequestBody videoFileUpdate: VideoFileUpdate,
+    ): VideoFileUpdate
 }

--- a/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/client/FileApiClient.kt
+++ b/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/client/FileApiClient.kt
@@ -2,21 +2,22 @@ package hu.bsstudio.bssweb.fileserver.client
 
 import hu.bsstudio.bssweb.fileserver.model.MemberFileUpdate
 import hu.bsstudio.bssweb.fileserver.model.VideoFileUpdate
-import org.springframework.cloud.openfeign.FeignClient
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.service.annotation.HttpExchange
+import org.springframework.web.service.annotation.PostExchange
+import org.springframework.web.service.annotation.PutExchange
 
-@FeignClient(name = "member", url = "\${bss.file-api.url}")
+@HttpExchange("/api/v1")
 interface FileApiClient {
-    @PostMapping("/api/v1/member")
-    fun createMemberFolder(fileUpdate: MemberFileUpdate): MemberFileUpdate
+    @PostExchange("/member")
+    fun createMemberFolder(@RequestBody fileUpdate: MemberFileUpdate): MemberFileUpdate
 
-    @PutMapping("/api/v1/member")
-    fun updateMemberFolder(fileUpdate: MemberFileUpdate): MemberFileUpdate
+    @PutExchange("/member")
+    fun updateMemberFolder(@RequestBody fileUpdate: MemberFileUpdate): MemberFileUpdate
 
-    @PostMapping("/api/v1/video")
-    fun createVideoFolder(videoFileUpdate: VideoFileUpdate): VideoFileUpdate
+    @PostExchange("/video")
+    fun createVideoFolder(@RequestBody videoFileUpdate: VideoFileUpdate): VideoFileUpdate
 
-    @PutMapping("/api/v1/video")
-    fun updateVideoFolder(videoFileUpdate: VideoFileUpdate): VideoFileUpdate
+    @PutExchange("/video")
+    fun updateVideoFolder(@RequestBody videoFileUpdate: VideoFileUpdate): VideoFileUpdate
 }

--- a/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/config/FileApiClientConfig.kt
+++ b/server/client/src/main/kotlin/hu/bsstudio/bssweb/fileserver/config/FileApiClientConfig.kt
@@ -1,9 +1,42 @@
 package hu.bsstudio.bssweb.fileserver.config
 
 import hu.bsstudio.bssweb.fileserver.client.FileApiClient
-import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.support.RestClientAdapter
+import org.springframework.web.service.invoker.HttpServiceProxyFactory
+import org.springframework.web.service.invoker.createClient
+import java.time.Duration
+import java.util.Base64
 
 @Configuration
-@EnableFeignClients(clients = [FileApiClient::class])
-class FileApiClientConfig
+class FileApiClientConfig {
+    @Bean
+    fun factory(
+        @Value($$"${bss.file-api.url}") baseUrl: String,
+        @Value($$"${bss.file-api.username}") username: String,
+        @Value($$"${bss.file-api.password}") password: String,
+    ): HttpServiceProxyFactory {
+        val auth = Base64.getEncoder().encodeToString("$username:$password".toByteArray())
+        val requestFactory =
+            SimpleClientHttpRequestFactory().apply {
+                setConnectTimeout(Duration.ofSeconds(10))
+                setReadTimeout(Duration.ofSeconds(30))
+            }
+        val restClient =
+            RestClient
+                .builder()
+                .baseUrl(baseUrl)
+                .requestFactory(requestFactory)
+                .defaultHeader("Authorization", "Basic $auth")
+                .build()
+        val adapter = RestClientAdapter.create(restClient)
+        return HttpServiceProxyFactory.builderFor(adapter).build()
+    }
+
+    @Bean
+    fun fileApiClient(factory: HttpServiceProxyFactory) = factory.createClient<FileApiClient>()
+}

--- a/server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -4,6 +4,16 @@
       "name": "bss.file-api.url",
       "type": "java.lang.String",
       "description": "BSS file API base URL."
+    },
+    {
+      "name": "bss.file-api.username",
+      "type": "java.lang.String",
+      "description": "BSS file API basic auth username."
+    },
+    {
+      "name": "bss.file-api.password",
+      "type": "java.lang.String",
+      "description": "BSS file API basic auth password."
     }
   ]
 }

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -1,6 +1,8 @@
 bss:
   file-api:
     url: http://localhost:8888
+    username: username
+    password: password
 spring:
   datasource:
     url: jdbc:tc:postgresql:16.3-alpine3.18:///db?currentSchema=private


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched the file-server backend client from Feign/OpenFeign to Spring Web’s HTTP exchange proxy.
  * Simplified Gradle dependencies by removing the OpenFeign starter from client and integration modules.
* **Security**
  * Updated dependency constraints related to a reported CVE to better align with the current dependency set.
* **Documentation**
  * Refreshed client README wording and updated the referenced backend client configuration naming.
* **Chores**
  * Updated build dependency management to rely on the Spring Boot BOM coordinates only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->