### PR TITLE
fix(sonar): harden CI installs and document empty context test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'release/pnpm-lock.yaml'
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
         working-directory: release
 
       - run: pnpm run release

--- a/server/src/test/kotlin/hu/bsstudio/bssweb/BssWebApplicationTest.kt
+++ b/server/src/test/kotlin/hu/bsstudio/bssweb/BssWebApplicationTest.kt
@@ -7,5 +7,6 @@ import org.springframework.boot.test.context.SpringBootTest
 class BssWebApplicationTest {
     @Test
     fun contextLoads() {
+        // verifies that the Spring application context starts successfully
     }
 }


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to release workflow pnpm install to resolve githubactions:S6505
- Document the intentional empty Spring Boot `contextLoads` test for kotlin:S1186

## Test plan
- [ ] CI passes on PR
- [ ] SonarCloud quality gate improves after merge

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification that the application context startup test verifies successful Spring application initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->