### PR TITLE
feat(integration): self-contained CI tests with dual-profile Testcontainers

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -51,8 +51,9 @@ jobs:
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-      - run: docker compose -f docker-compose.yml --profile app up --wait --build
       - run: "./gradlew integrationTest --continue"
+        env:
+          REBUILD_IMAGES: "true"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "gradle-integration-artifacts"

--- a/buildSrc/src/main/kotlin/hu/bsstudio/gradle/IntegrationTestConventionPlugin.kt
+++ b/buildSrc/src/main/kotlin/hu/bsstudio/gradle/IntegrationTestConventionPlugin.kt
@@ -3,10 +3,12 @@ package hu.bsstudio.gradle
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.jvm.JvmTestSuite
+import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.exclude
 import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
 import org.gradle.testing.base.TestingExtension
 
 class IntegrationTestConventionPlugin : Plugin<Project> {
@@ -31,6 +33,28 @@ class IntegrationTestConventionPlugin : Plugin<Project> {
         project.configurations.named("integrationTestImplementation") {
             extendsFrom(project.configurations.getByName("implementation"))
             extendsFrom(project.configurations.getByName("runtimeOnly"))
+        }
+        project.afterEvaluate {
+            project.tasks.withType<Test>().matching { it.name == "integrationTest" }.configureEach {
+                if (System.getenv("CI") != null) {
+                    systemProperty("spring.profiles.active", "ci")
+                }
+                val root = project.rootProject
+                inputs
+                    .files(
+                        root.file("docker-compose.yml"),
+                        root.file("docker-compose.ci.yml"),
+                        root.file("Dockerfile"),
+                        root.fileTree("docker/wiremock"),
+                    ).withPropertyName("infrastructure")
+                root.tasks.findByPath(":server:bootJar")?.let { bootJar ->
+                    inputs.files(bootJar.outputs.files).withPropertyName("appArtifact")
+                }
+                inputs
+                    .property("integrationProfile") {
+                        if (System.getenv("CI") != null) "ci" else "default"
+                    }
+            }
         }
     }
 }

--- a/integration/README.md
+++ b/integration/README.md
@@ -2,17 +2,34 @@
 
 It stores the integration tests for the application.
 
-To run the integration tests, you need to have Docker installed on your machine.
+Each integration test extends the `IntegrationTest` class. Tests use a real Postgres database and
+call the application over HTTP. Each test clears the database tables in `@BeforeEach`.
 
-Testcontainers didn't have a clean way to start the compose file before all the tests.
-So it's required to start the compose file manually before running the tests.
-Each test will clear the database tables.
+## Local (default profile)
 
-Each Integration test has to extend the `IntegrationTest` class.
+Start the compose stack once, then re-run tests freely:
 
 ```shell
-docker compose up -d
+docker compose --profile app up -d
 ./gradlew integrationTest
-docker compose down
 ```
 
+Optionally start the app via Spring Boot (requires `spring-boot-docker-compose` on the server module):
+
+```shell
+./gradlew :server:bootRun
+./gradlew integrationTest
+```
+
+## CI (`ci` profile)
+
+GitHub Actions runs a self-contained integration test: Testcontainers starts the compose stack,
+runs tests, and tears it down. To reproduce locally:
+
+```shell
+CI=true REBUILD_IMAGES=true ./gradlew integrationTest
+```
+
+## Requirements
+
+Docker must be installed and running.

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -17,4 +17,6 @@ dependencies {
     integrationTestImplementation("org.springframework.boot:spring-boot-starter-json")
     integrationTestImplementation("org.springframework.boot:spring-boot-data-jpa-test")
     integrationTestImplementation("org.springframework.boot:spring-boot-starter-validation-test")
+    integrationTestImplementation("org.springframework.boot:spring-boot-testcontainers")
+    integrationTestImplementation("org.testcontainers:testcontainers")
 }

--- a/integration/src/integrationTest/kotlin/hu/bsstudio/bssweb/CiTestContainerConfiguration.kt
+++ b/integration/src/integrationTest/kotlin/hu/bsstudio/bssweb/CiTestContainerConfiguration.kt
@@ -1,0 +1,36 @@
+package hu.bsstudio.bssweb
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Profile
+import org.springframework.test.context.DynamicPropertyRegistrar
+import org.testcontainers.containers.ComposeContainer
+import java.io.File
+
+@Profile("ci")
+@TestConfiguration(proxyBeanMethods = false)
+class CiTestContainerConfiguration {
+    @Bean
+    fun dockerComposeContainer(): ComposeContainer =
+        ComposeContainer(
+            File("../docker-compose.yml"),
+            File("../docker-compose.ci.yml"),
+        ).withExposedService("postgres", 5432)
+            .withExposedService("app", 8080)
+            .withEnv("COMPOSE_PROFILES", "app")
+            .withBuild(System.getenv("REBUILD_IMAGES")?.toBoolean() ?: false)
+
+    @Bean
+    fun ciIntegrationProperties(compose: ComposeContainer): DynamicPropertyRegistrar =
+        DynamicPropertyRegistrar { registry ->
+            registry.add("spring.datasource.url") {
+                "jdbc:postgresql://${compose.getServiceHost("postgres", 5432)}:" +
+                    "${compose.getServicePort("postgres", 5432)}/bss?currentSchema=private"
+            }
+            registry.add("spring.datasource.username") { "user" }
+            registry.add("spring.datasource.password") { "password" }
+            registry.add("bss.client.url") {
+                "http://${compose.getServiceHost("app", 8080)}:${compose.getServicePort("app", 8080)}"
+            }
+        }
+}

--- a/integration/src/integrationTest/kotlin/hu/bsstudio/bssweb/IntegrationTest.kt
+++ b/integration/src/integrationTest/kotlin/hu/bsstudio/bssweb/IntegrationTest.kt
@@ -9,21 +9,13 @@ import hu.bsstudio.bssweb.video.repository.DetailedVideoRepository
 import hu.bsstudio.bssweb.videocrew.repository.VideoCrewRepository
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.TestPropertySource
-import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import org.springframework.boot.test.context.SpringBootTest
 
-@SpringJUnitConfig(classes = [BssWebAdminBackendClientConfig::class, DataConfig::class])
-@TestPropertySource(
-    properties = [
-        "bss.client.url=http://localhost:8080",
-        "bss.client.token=token",
-        "spring.flyway.enabled=false",
-        "spring.datasource.url=jdbc:postgresql://localhost:5432/bss?currentSchema=private",
-        "spring.datasource.username=user",
-        "spring.datasource.password=password",
-    ],
+@SpringBootTest(
+    classes = [CiTestContainerConfiguration::class, BssWebAdminBackendClientConfig::class, DataConfig::class],
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
 )
-open class IntegrationTest {
+class IntegrationTest {
     @Autowired protected lateinit var eventRepository: DetailedEventRepository
 
     @Autowired protected lateinit var videoRepository: DetailedVideoRepository

--- a/integration/src/integrationTest/resources/application.yml
+++ b/integration/src/integrationTest/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://127.0.0.1:5432/bss?currentSchema=private
+    username: user
+    password: password
+bss:
+  client:
+    url: http://127.0.0.1:8080
+    token: token

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
+    developmentOnly("org.springframework.boot:spring-boot-docker-compose")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:testcontainers-postgresql")

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: BSS Web admin API
+  docker:
+    compose:
+      profiles:
+        active: app
   jpa:
     open-in-view: false
 springdoc:


### PR DESCRIPTION
## Summary

- Add dual-profile integration tests: **local default** uses fixed localhost URLs from `application.yml` against a pre-started compose stack; **CI (`ci` profile)** uses Testcontainers `ComposeContainer` to start/stop compose with dynamic JDBC and client URLs.
- Simplify GitHub Actions by removing the manual `docker compose up` step; CI sets `REBUILD_IMAGES=true` so the app image is built inside the Testcontainers lifecycle.
- Activate the `ci` profile via Gradle when `CI` is set, declare infrastructure/bootJar cache inputs, and add optional `spring-boot-docker-compose` for local `bootRun`.

## Test plan

- [x] Local: `docker compose --profile app up -d` then `./gradlew integrationTest` (55 tests pass)
- [x] CI profile locally: `CI=true REBUILD_IMAGES=true ./gradlew integrationTest` (55 tests pass, Testcontainers compose lifecycle verified in test reports)
- [x] Gradle cache: `integrationTest` is UP-TO-DATE when inputs unchanged


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integration tests can now automatically start the required application and PostgreSQL services.
  - CI test runs support automatic Docker image rebuilding and dynamic service connection settings.
  - Local development can use the application’s Docker Compose profile or an optional Spring Boot startup.

- **Documentation**
  - Updated integration testing guidance covers prerequisites, local and CI workflows, HTTP communication, database cleanup, and test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->